### PR TITLE
Remove anonymous gist support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ text you will be prompted for a description.
 -p, --private: This creates a private gist. Public is the default.
               See g:gist_default_private to change this default.
 
--a, --anonymous: Create a anonymous gist.
-
 -o, --open: Open the created Gist in the browser after it's created.
           This is on by default.
           See g:gist_open_url to change this default.

--- a/doc/gist.txt
+++ b/doc/gist.txt
@@ -40,8 +40,6 @@ This takes multiple options each with have a long and short flag.
     --private: This creates a private gist. Public is the default.
                See |gist_default_private| to change this default.
 
-    --anonymous: Create a anonymous gist.
-
     --open: Open the created Gist in the browser after it's created.
             This is on by default.
             See |gist_open_url| to change this default.
@@ -74,8 +72,7 @@ The other commands are very simple:
     :GistCopyLast
 
 These commands takes no arguments. They copy or open the last created Gist in
-the browser. This can be useful if you create an anonymous gist without
-copying or opening it immediately, or if you just want the convenience.
+the browser.
 
 
 ==============================================================================

--- a/gist/gist.py
+++ b/gist/gist.py
@@ -20,12 +20,11 @@ def main(args):
     if not data:
         return
 
-    user = None
-    if not name.anonymous:
-        user = User.from_netrc(url=github_url())
-        if not user:
-            print("No user with machine %s" % github_url())
-            return
+    user = User.from_netrc(url=github_url())
+    if not user:
+        print("No user with machine %s" % github_url())
+        return
+
     request = request_for_user(user)
 
     try:
@@ -237,8 +236,6 @@ if __name__ == "__main__":
                         dest='public', default=(not private_default))
     parser.add_argument('-p', '--private', action='store_false',
                         dest='public')
-    parser.add_argument('-a', '--anonymous', action='store_true',
-                        default=False)
     parser.add_argument('-o', '--open', action='store_true',
                         dest='open_browser', default=open_default)
     parser.add_argument('-y', '--yank', action='store_true',

--- a/plugin/gist.vim
+++ b/plugin/gist.vim
@@ -40,7 +40,6 @@ function! s:CompleteArguments(ArgLead, CmdLine, CursorPos)
   return [
         \ '--public',
         \ '--private',
-        \ '--anonymous',
         \ '--open'
       \ ]
 endfunction


### PR DESCRIPTION
GitHub is killing this feature: https://github.com/blog/2503-deprecation-notice-removing-anonymous-gist-creation