### PR TITLE
Remove need for login

### DIFF
--- a/gist/auth/user.py
+++ b/gist/auth/user.py
@@ -30,7 +30,7 @@ class User(object):
         login, account, password = credential
         if not login:
             login = account
-        if not login or not password:
+        if not password:
             return None
 
         return User(login, password, url)

--- a/gist/gist.py
+++ b/gist/gist.py
@@ -27,7 +27,7 @@ def main(args):
 
     request = urllib.request.Request(github_url("gists"))
     request.add_header(
-        "Authorization", "Basic %s" % auth_for_user(user).decode()
+        "Authorization", "Bearer %s" % user.password
     )
 
     try:
@@ -74,15 +74,6 @@ def data_for_args(name, unknown):
         return None
     data["description"] = desc
     return data
-
-
-def auth_for_user(user):
-    """
-    Formats the base64 string based on a user
-    """
-    return base64.standard_b64encode(
-        "{}:{}".format(user.username, user.password).encode()
-    )
 
 
 def github_url(path=""):


### PR DESCRIPTION
This predates PATs, now we can just ignore that field. This could be
useful if we supported multiple github accounts, but that's not the case
right now
